### PR TITLE
Register quotaUsage metric

### DIFF
--- a/metrics_azurerm_quota.go
+++ b/metrics_azurerm_quota.go
@@ -82,6 +82,7 @@ func (m *MetricsCollectorAzureRmQuota) Setup(collector *CollectorGeneral) {
 	prometheus.MustRegister(m.prometheus.quota)
 	prometheus.MustRegister(m.prometheus.quotaCurrent)
 	prometheus.MustRegister(m.prometheus.quotaLimit)
+	prometheus.MustRegister(m.prometheus.quotaUsage)
 }
 
 func (m *MetricsCollectorAzureRmQuota) Reset() {


### PR DESCRIPTION
The `azurerm_quota_usage` is currently not registered and therefore not being sent to Prometheus.