### PR TITLE
Update metrics_graphos.go to support advanced query parameters

### DIFF
--- a/metrics_graph_apps.go
+++ b/metrics_graph_apps.go
@@ -55,8 +55,10 @@ func (m *MetricsCollectorGraphApps) Setup(collector *collector.Collector) {
 func (m *MetricsCollectorGraphApps) Reset() {}
 
 func (m *MetricsCollectorGraphApps) Collect(callback chan<- func()) {
+	headers := abstractions.NewRequestHeaders()
+	headers.Add("ConsistencyLevel", "eventual")
 	opts := applications.ApplicationsRequestBuilderGetRequestConfiguration{
-		Headers: nil,
+		Headers: headers,
 		Options: nil,
 		QueryParameters: &applications.ApplicationsRequestBuilderGetQueryParameters{
 			Filter: &opts.Graph.ApplicationFilter,


### PR DESCRIPTION
Some query parameters are currently behind an additional header flag that needs to be added.

The headers required are ConsistencyLevel=eventual as per https://learn.microsoft.com/en-us/graph/aad-advanced-queries?tabs=go