### PR TITLE
Costs: Allow custom scopes

### DIFF
--- a/config/opts.go
+++ b/config/opts.go
@@ -57,6 +57,7 @@ type (
 			Queries      []string      `long:"costs.query"                                              description:"Cost query in format: 'queryname=dimension' or 'queryname=dimension1,dimension2,dimension3'. Dimensions can be: 'ResourceGroupName','ResourceLocation','ConsumedService','ResourceType','ResourceId','MeterId','BillingMonth','MeterCategory','MeterSubcategory','Meter','AccountName','DepartmentName','SubscriptionId','SubscriptionName','ServiceName','ServiceTier','EnrollmentAccountName','BillingAccountId','ResourceGuid','BillingPeriod','InvoiceNumber','ChargeType','PublisherType','ReservationId','ReservationName','Frequency','PartNumber','CostAllocationRuleName','MarkupRuleName','PricingModel'. Can be specified in env vars as COSTS_QUERY_queryname=Dimensions"`
 			ValueField   string        `long:"costs.value"                                              description:"Value field for cost query" choice:"Cost" choice:"PreTaxCost" default:"PreTaxCost"` //nolint:staticcheck
 			RequestDelay time.Duration `long:"costs.request.delay" env:"COSTS_REQUEST_DELAY" description:"Delay API requests by this time to avoid ratelimits" default:"10s"`
+			Scopes       []string      `long:"costs.scopes" env:"COSTS_SCOPES" env-delim:" " description:"If non-empty, use this list of scopes instead the configured subscriptions (space delimiter). See https://learn.microsoft.com/en-us/rest/api/cost-management/query/usage?tabs=HTTP for supported scopes." optional:"true"`
 		}
 
 		// portscan settings


### PR DESCRIPTION
This PR adds the ability to fetch cost metrics on different scopes. Looking at #20, using different scopes provides a scaling solution independently from the number of subscriptions.

Example: Fetch Costs metrics at MG level:
```
--costs.scopes=/providers/Microsoft.Management/managementGroups/shared
```

Example: Fetch Costs metrics at billing account:
```
--costs.scopes=/providers/Microsoft.Billing/billingAccounts/{billingAccountId}
```

Supported scopes

* '/subscriptions/{subscriptionId}/' for subscription scope
* '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for resourceGroup scope
* '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for Billing Account scope 
* '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/departments/{departmentId}' for Department scope
* '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/enrollmentAccounts/{enrollmentAccountId}' for EnrollmentAccount scope
* '/providers/Microsoft.Management/managementGroups/{managementGroupId} for Management Group scope
* '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}' for billingProfile scope
* '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}/invoiceSections/{invoiceSectionId}' for invoiceSection scope
* '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/customers/{customerId}' specific for partners
