### PR TITLE
add budget metrics by scope (subscriptions/billing account) and budget forecast metric

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type (
 			Iam            CollectorBase           `yaml:"iam"`
 			Graph          CollectorGraph          `yaml:"graph"`
 			Costs          CollectorCosts          `yaml:"costs"`
+			Budgets        CollectorBudgets        `yaml:"budgets"`
 			Reservation    CollectorReservation    `yaml:"reservation"`
 			Portscan       CollectorPortscan       `yaml:"portscan"`
 		} `yaml:"collectors"`

--- a/config/config_budget.go
+++ b/config/config_budget.go
@@ -1,0 +1,9 @@
+package config
+
+type (
+	CollectorBudgets struct {
+		CollectorBase `yaml:",inline"`
+
+		Scopes []string `yaml:"scopes"`
+	}
+)

--- a/default.yaml
+++ b/default.yaml
@@ -23,6 +23,8 @@ collectors:
 
   costs: {}
 
+  budgets: {}
+
   reservation: {}
 
   portscan:

--- a/example.yaml
+++ b/example.yaml
@@ -55,7 +55,7 @@ collectors:
       application:      ""
       servicePrincipal: ""
 
-  # Azure cost metrics (cost queries, budgets)
+  # Azure cost metrics (cost queries)
   # needs queries below
   costs:
     scrapeTime: 60m
@@ -103,6 +103,23 @@ collectors:
 
         # optional, additional static labels
         labels: {}
+
+  # Azure budget metrics
+  budgets:
+    scrapeTime: 1h
+
+    # optional, see https://learn.microsoft.com/en-us/rest/api/cost-management/query/usage?tabs=HTTP
+    # will disable fetching by subscription and will enable fetching by scope
+    #scopes: [...]
+    # '/subscriptions/{subscriptionId}/' for subscription scope
+    # '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for resourceGroup scope
+    # '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for Billing Account scope
+    # '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/departments/{departmentId}' for Department scope
+    # '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/enrollmentAccounts/{enrollmentAccountId}' for EnrollmentAccount scope
+    # '/providers/Microsoft.Management/managementGroups/{managementGroupId} for Management Group scope
+    # '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}' for billingProfile scope
+    # '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}/invoiceSections/{invoiceSectionId}' for invoiceSection scope
+    # '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/customers/{customerId}' specific for partners
 
   reservation:
     scrapeTime: 1h

--- a/main.go
+++ b/main.go
@@ -258,6 +258,21 @@ func initMetricCollector() {
 		logger.With(zap.String("collector", collectorName)).Infof("collector disabled")
 	}
 
+	collectorName = "budgets"
+	if Config.Collectors.Budgets.IsEnabled() {
+		c := collector.New(collectorName, &MetricsCollectorAzureRmBudgets{}, logger)
+		c.SetScapeTime(*Config.Collectors.Budgets.ScrapeTime)
+		c.SetCache(
+			Opts.GetCachePath(collectorName+".json"),
+			collector.BuildCacheTag(cacheTag, Config.Azure, Config.Collectors.Budgets),
+		)
+		if err := c.Start(); err != nil {
+			logger.Fatal(err.Error())
+		}
+	} else {
+		logger.With(zap.String("collector", collectorName)).Infof("collector disabled")
+	}
+
 	collectorName = "defender"
 	if Config.Collectors.Defender.IsEnabled() {
 		c := collector.New(collectorName, &MetricsCollectorAzureRmDefender{}, logger)

--- a/metrics_azurerm_budgets.go
+++ b/metrics_azurerm_budgets.go
@@ -20,9 +20,6 @@ type MetricsCollectorAzureRmBudgets struct {
 		consumptionBudgetCurrent  *prometheus.GaugeVec
 		consumptionBudgetForecast *prometheus.GaugeVec
 		consumptionBudgetUsage    *prometheus.GaugeVec
-
-		costmanagementOverallUsage      *prometheus.GaugeVec
-		costmanagementOverallActualCost *prometheus.GaugeVec
 	}
 }
 

--- a/metrics_azurerm_budgets.go
+++ b/metrics_azurerm_budgets.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/webdevops/go-common/azuresdk/armclient"
+	"github.com/webdevops/go-common/prometheus/collector"
+	"github.com/webdevops/go-common/utils/to"
+	"go.uber.org/zap"
+)
+
+// Define MetricsCollectorAzureRmBudgets struct
+type MetricsCollectorAzureRmBudgets struct {
+	collector.Processor
+
+	prometheus struct {
+		consumptionBudgetInfo     *prometheus.GaugeVec
+		consumptionBudgetLimit    *prometheus.GaugeVec
+		consumptionBudgetCurrent  *prometheus.GaugeVec
+		consumptionBudgetForecast *prometheus.GaugeVec
+		consumptionBudgetUsage    *prometheus.GaugeVec
+
+		costmanagementOverallUsage      *prometheus.GaugeVec
+		costmanagementOverallActualCost *prometheus.GaugeVec
+	}
+}
+
+// Setup method to initialize Prometheus metrics
+func (m *MetricsCollectorAzureRmBudgets) Setup(collector *collector.Collector) {
+	m.Processor.Setup(collector)
+
+	// ----------------------------------------------------
+	// Budget
+	m.prometheus.consumptionBudgetInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "azurerm_budgets_info",
+			Help: "Azure ResourceManager consumption budget info",
+		},
+		[]string{
+			"scope",
+			"resourceID",
+			"subscriptionID",
+			"budgetName",
+			"resourceGroup",
+			"category",
+			"timeGrain",
+		},
+	)
+	m.Collector.RegisterMetricList("consumptionBudgetInfo", m.prometheus.consumptionBudgetInfo, true)
+
+	m.prometheus.consumptionBudgetLimit = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "azurerm_budgets_limit",
+			Help: "Azure ResourceManager consumption budget limit",
+		},
+		[]string{
+			"scope",
+			"resourceID",
+			"subscriptionID",
+			"resourceGroup",
+			"budgetName",
+		},
+	)
+	m.Collector.RegisterMetricList("consumptionBudgetLimit", m.prometheus.consumptionBudgetLimit, true)
+
+	m.prometheus.consumptionBudgetUsage = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "azurerm_budgets_usage",
+			Help: "Azure ResourceManager consumption budget usage percentage",
+		},
+		[]string{
+			"scope",
+			"resourceID",
+			"subscriptionID",
+			"resourceGroup",
+			"budgetName",
+		},
+	)
+	m.Collector.RegisterMetricList("consumptionBudgetUsage", m.prometheus.consumptionBudgetUsage, true)
+
+	m.prometheus.consumptionBudgetCurrent = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "azurerm_budgets_current",
+			Help: "Azure ResourceManager consumption budget current",
+		},
+		[]string{
+			"scope",
+			"resourceID",
+			"subscriptionID",
+			"resourceGroup",
+			"budgetName",
+			"unit",
+		},
+	)
+	m.Collector.RegisterMetricList("consumptionBudgetCurrent", m.prometheus.consumptionBudgetCurrent, true)
+
+	m.prometheus.consumptionBudgetForecast = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "azurerm_budgets_forecast",
+			Help: "Azure ResourceManager consumption budget forecast",
+		},
+		[]string{
+			"scope",
+			"resourceID",
+			"subscriptionID",
+			"resourceGroup",
+			"budgetName",
+			"unit",
+		},
+	)
+	m.Collector.RegisterMetricList("consumptionBudgetForecast", m.prometheus.consumptionBudgetForecast, true)
+}
+
+func (m *MetricsCollectorAzureRmBudgets) Reset() {}
+
+func (m *MetricsCollectorAzureRmBudgets) Collect(callback chan<- func()) {
+	if Config.Collectors.Budgets.Scopes != nil && len(Config.Collectors.Budgets.Scopes) > 0 {
+		for _, scope := range Config.Collectors.Budgets.Scopes {
+			// Run the budget query for the current scope
+			m.collectBudgetMetrics(logger, scope, callback)
+		}
+	} else {
+		// using subscription iterator
+		iterator := AzureSubscriptionsIterator
+
+		err := iterator.ForEach(m.Logger(), func(subscription *armsubscriptions.Subscription, logger *zap.SugaredLogger) {
+			m.collectBudgetMetrics(
+				logger,
+				*subscription.ID,
+				callback,
+			)
+		})
+		if err != nil {
+			m.Logger().Panic(err)
+		}
+	}
+}
+
+func (m *MetricsCollectorAzureRmBudgets) collectBudgetMetrics(logger *zap.SugaredLogger, scope string, callback chan<- func()) {
+	clientFactory, err := armconsumption.NewClientFactory("<subscription-id>", AzureClient.GetCred(), AzureClient.NewArmClientOptions())
+	if err != nil {
+		logger.Panic(err)
+	}
+
+	infoMetric := m.Collector.GetMetricList("consumptionBudgetInfo")
+	usageMetric := m.Collector.GetMetricList("consumptionBudgetUsage")
+	limitMetric := m.Collector.GetMetricList("consumptionBudgetLimit")
+	currentMetric := m.Collector.GetMetricList("consumptionBudgetCurrent")
+	forecastMetric := m.Collector.GetMetricList("consumptionBudgetForecast")
+
+	pager := clientFactory.NewBudgetsClient().NewListPager(scope, nil)
+
+	for pager.More() {
+		result, err := pager.NextPage(m.Context())
+		if err != nil {
+			logger.Panic(err)
+		}
+
+		if result.Value == nil {
+			continue
+		}
+
+		for _, budget := range result.Value {
+			resourceId := to.String(budget.ID)
+
+			azureResource, _ := armclient.ParseResourceId(resourceId)
+
+			infoMetric.AddInfo(prometheus.Labels{
+				"scope":          scope,
+				"resourceID":     stringToStringLower(resourceId),
+				"subscriptionID": azureResource.Subscription,
+				"resourceGroup":  azureResource.ResourceGroup,
+				"budgetName":     to.String(budget.Name),
+				"category":       stringToStringLower(string(*budget.Properties.Category)),
+				"timeGrain":      string(*budget.Properties.TimeGrain),
+			})
+
+			if budget.Properties.Amount != nil {
+				limitMetric.Add(prometheus.Labels{
+					"scope":          scope,
+					"resourceID":     stringToStringLower(resourceId),
+					"subscriptionID": azureResource.Subscription,
+					"resourceGroup":  azureResource.ResourceGroup,
+					"budgetName":     to.String(budget.Name),
+				}, *budget.Properties.Amount)
+			}
+
+			if budget.Properties.CurrentSpend != nil {
+				currentMetric.Add(prometheus.Labels{
+					"scope":          scope,
+					"resourceID":     stringToStringLower(resourceId),
+					"subscriptionID": azureResource.Subscription,
+					"resourceGroup":  azureResource.ResourceGroup,
+					"budgetName":     to.String(budget.Name),
+					"unit":           to.StringLower(budget.Properties.CurrentSpend.Unit),
+				}, *budget.Properties.CurrentSpend.Amount)
+			}
+
+			if budget.Properties.ForecastSpend != nil {
+				forecastMetric.Add(prometheus.Labels{
+					"scope":          scope,
+					"resourceID":     stringToStringLower(resourceId),
+					"subscriptionID": azureResource.Subscription,
+					"resourceGroup":  azureResource.ResourceGroup,
+					"budgetName":     to.String(budget.Name),
+					"unit":           to.StringLower(budget.Properties.ForecastSpend.Unit),
+				}, *budget.Properties.ForecastSpend.Amount)
+			}
+
+			if budget.Properties.Amount != nil && budget.Properties.CurrentSpend != nil {
+				usageMetric.Add(prometheus.Labels{
+					"scope":          scope,
+					"resourceID":     stringToStringLower(resourceId),
+					"subscriptionID": azureResource.Subscription,
+					"resourceGroup":  azureResource.ResourceGroup,
+					"budgetName":     to.String(budget.Name),
+				}, *budget.Properties.CurrentSpend.Amount / *budget.Properties.Amount)
+			}
+		}
+	}
+}

--- a/metrics_azurerm_costs.go
+++ b/metrics_azurerm_costs.go
@@ -11,7 +11,6 @@ import (
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/costmanagement/armcostmanagement"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 	"github.com/prometheus/client_golang/prometheus"
@@ -33,11 +32,6 @@ type (
 		collector.Processor
 
 		prometheus struct {
-			consumptionBudgetInfo    *prometheus.GaugeVec
-			consumptionBudgetLimit   *prometheus.GaugeVec
-			consumptionBudgetCurrent *prometheus.GaugeVec
-			consumptionBudgetUsage   *prometheus.GaugeVec
-
 			costmanagementOverallUsage      *prometheus.GaugeVec
 			costmanagementOverallActualCost *prometheus.GaugeVec
 		}
@@ -66,67 +60,6 @@ type (
 
 func (m *MetricsCollectorAzureRmCosts) Setup(collector *collector.Collector) {
 	m.Processor.Setup(collector)
-
-	// ----------------------------------------------------
-	// Budget
-	m.prometheus.consumptionBudgetInfo = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "azurerm_costs_budget_info",
-			Help: "Azure ResourceManager consumption budget info",
-		},
-		[]string{
-			"resourceID",
-			"subscriptionID",
-			"budgetName",
-			"resourceGroup",
-			"category",
-			"timeGrain",
-		},
-	)
-	m.Collector.RegisterMetricList("consumptionBudgetInfo", m.prometheus.consumptionBudgetInfo, true)
-
-	m.prometheus.consumptionBudgetLimit = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "azurerm_costs_budget_limit",
-			Help: "Azure ResourceManager consumption budget limit",
-		},
-		[]string{
-			"resourceID",
-			"subscriptionID",
-			"resourceGroup",
-			"budgetName",
-		},
-	)
-	m.Collector.RegisterMetricList("consumptionBudgetLimit", m.prometheus.consumptionBudgetLimit, true)
-
-	m.prometheus.consumptionBudgetUsage = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "azurerm_costs_budget_usage",
-			Help: "Azure ResourceManager consumption budget usage percentage",
-		},
-		[]string{
-			"resourceID",
-			"subscriptionID",
-			"resourceGroup",
-			"budgetName",
-		},
-	)
-	m.Collector.RegisterMetricList("consumptionBudgetUsage", m.prometheus.consumptionBudgetUsage, true)
-
-	m.prometheus.consumptionBudgetCurrent = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "azurerm_costs_budget_current",
-			Help: "Azure ResourceManager consumption budget current",
-		},
-		[]string{
-			"resourceID",
-			"subscriptionID",
-			"resourceGroup",
-			"budgetName",
-			"unit",
-		},
-	)
-	m.Collector.RegisterMetricList("consumptionBudgetCurrent", m.prometheus.consumptionBudgetCurrent, true)
 
 	// ----------------------------------------------------
 	// Costs (by Query)
@@ -194,18 +127,6 @@ func (m *MetricsCollectorAzureRmCosts) Collect(callback chan<- func()) {
 
 		m.collectRunCostQuery(&query, exportType, callback)
 	}
-
-	// run budget collection
-	err := AzureSubscriptionsIterator.ForEach(m.Logger(), func(subscription *armsubscriptions.Subscription, logger *zap.SugaredLogger) {
-		logger.Info(`fetching cost budget report`)
-		m.collectBudgetMetrics(
-			logger.With(zap.String("consumption", "Budgets")),
-			subscription,
-		)
-	})
-	if err != nil {
-		m.Logger().Panic(err)
-	}
 }
 
 func (m *MetricsCollectorAzureRmCosts) collectRunCostQuery(query *config.CollectorCostsQuery, exportType armcostmanagement.ExportType, callback chan<- func()) {
@@ -247,73 +168,6 @@ func (m *MetricsCollectorAzureRmCosts) collectRunCostQuery(query *config.Collect
 			})
 			if err != nil {
 				m.Logger().Panic(err)
-			}
-		}
-	}
-}
-
-func (m *MetricsCollectorAzureRmCosts) collectBudgetMetrics(logger *zap.SugaredLogger, subscription *armsubscriptions.Subscription) {
-	client, err := armconsumption.NewBudgetsClient(AzureClient.GetCred(), AzureClient.NewArmClientOptions())
-	if err != nil {
-		logger.Panic(err)
-	}
-
-	infoMetric := m.Collector.GetMetricList("consumptionBudgetInfo")
-	usageMetric := m.Collector.GetMetricList("consumptionBudgetUsage")
-	limitMetric := m.Collector.GetMetricList("consumptionBudgetLimit")
-	currentMetric := m.Collector.GetMetricList("consumptionBudgetCurrent")
-
-	pager := client.NewListPager(*subscription.ID, nil)
-
-	for pager.More() {
-		result, err := pager.NextPage(m.Context())
-		if err != nil {
-			logger.Panic(err)
-		}
-
-		if result.Value == nil {
-			continue
-		}
-
-		for _, budget := range result.Value {
-			resourceId := to.String(budget.ID)
-			azureResource, _ := armclient.ParseResourceId(resourceId)
-
-			infoMetric.AddInfo(prometheus.Labels{
-				"resourceID":     stringToStringLower(resourceId),
-				"subscriptionID": azureResource.Subscription,
-				"resourceGroup":  azureResource.ResourceGroup,
-				"budgetName":     to.String(budget.Name),
-				"category":       stringToStringLower(string(*budget.Properties.Category)),
-				"timeGrain":      string(*budget.Properties.TimeGrain),
-			})
-
-			if budget.Properties.Amount != nil {
-				limitMetric.Add(prometheus.Labels{
-					"resourceID":     stringToStringLower(resourceId),
-					"subscriptionID": azureResource.Subscription,
-					"resourceGroup":  azureResource.ResourceGroup,
-					"budgetName":     to.String(budget.Name),
-				}, *budget.Properties.Amount)
-			}
-
-			if budget.Properties.CurrentSpend != nil {
-				currentMetric.Add(prometheus.Labels{
-					"resourceID":     stringToStringLower(resourceId),
-					"subscriptionID": azureResource.Subscription,
-					"resourceGroup":  azureResource.ResourceGroup,
-					"budgetName":     to.String(budget.Name),
-					"unit":           to.StringLower(budget.Properties.CurrentSpend.Unit),
-				}, *budget.Properties.CurrentSpend.Amount)
-			}
-
-			if budget.Properties.Amount != nil && budget.Properties.CurrentSpend != nil {
-				usageMetric.Add(prometheus.Labels{
-					"resourceID":     stringToStringLower(resourceId),
-					"subscriptionID": azureResource.Subscription,
-					"resourceGroup":  azureResource.ResourceGroup,
-					"budgetName":     to.String(budget.Name),
-				}, *budget.Properties.CurrentSpend.Amount / *budget.Properties.Amount)
 			}
 		}
 	}

--- a/metrics_azurerm_costs.go
+++ b/metrics_azurerm_costs.go
@@ -28,15 +28,6 @@ const (
 )
 
 type (
-	MetricsCollectorAzureRmCosts struct {
-		collector.Processor
-
-		prometheus struct {
-			costmanagementOverallUsage      *prometheus.GaugeVec
-			costmanagementOverallActualCost *prometheus.GaugeVec
-		}
-	}
-
 	MetricsCollectorAzureRmCostsQuery struct {
 		Name       string
 		Dimensions []MetricsCollectorAzureRmCostsQueryDimension

--- a/metrics_azurerm_costs.go
+++ b/metrics_azurerm_costs.go
@@ -28,6 +28,10 @@ const (
 )
 
 type (
+	MetricsCollectorAzureRmCosts struct {
+		collector.Processor
+	}
+
 	MetricsCollectorAzureRmCostsQuery struct {
 		Name       string
 		Dimensions []MetricsCollectorAzureRmCostsQueryDimension


### PR DESCRIPTION
- Externalize budget from costs
- Add the possibility to specify the scope for budget and more specifically billing account.
_by default, if scope is not specified, it use all subscriptions of the Azure tenant._
- Add the forecast budget

```# Azure budget metrics
  budgets:
    scrapeTime: 1h

    # optional, see https://learn.microsoft.com/en-us/rest/api/cost-management/query/usage?tabs=HTTP
    # will disable fetching by subscription and will enable fetching by scope
    #scopes: [...]
    # '/subscriptions/{subscriptionId}/' for subscription scope
    # '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for resourceGroup scope
    # '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for Billing Account scope
    # '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/departments/{departmentId}' for Department scope
    # '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/enrollmentAccounts/{enrollmentAccountId}' for EnrollmentAccount scope
    # '/providers/Microsoft.Management/managementGroups/{managementGroupId} for Management Group scope
    # '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}' for billingProfile scope
    # '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfiles/{billingProfileId}/invoiceSections/{invoiceSectionId}' for invoiceSection scope
    # '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/customers/{customerId}' specific for partners
```
    
    
   No changes on metrics and labels, just add _**azurerm_budgets_forecast**_

   ```
   # HELP azurerm_budgets_current Azure ResourceManager consumption budget current
# TYPE azurerm_budgets_current gauge
azurerm_budgets_current{budgetName="Azure_Example_Budget",resourceGroup="",resourceID="/subscriptions/<subscription-id>/providers/microsoft.consumption/budgets/Azure_Example_Budget",scope="/subscriptions/<subscription-id>/",subscriptionID="<subscription-id>",unit="eur"} 24.125064975169156
# HELP azurerm_budgets_forecast Azure ResourceManager consumption budget forecast
# TYPE azurerm_budgets_forecast gauge
azurerm_budgets_forecast{budgetName="Azure_Example_Budget",resourceGroup="",resourceID="/subscriptions/<subscription-id>/providers/microsoft.consumption/budgets/Azure_Example_Budget",scope="/subscriptions/<subscription-id>/",subscriptionID="<subscription-id>",unit="eur"} 88.870500129221
# HELP azurerm_budgets_info Azure ResourceManager consumption budget info
# TYPE azurerm_budgets_info gauge
azurerm_budgets_info{budgetName="Azure_Example_Budget",category="cost",resourceGroup="",resourceID="/subscriptions/<subscription-id>/providers/microsoft.consumption/budgets/Azure_Example_Budget",scope="/subscriptions/<subscription-id>/",subscriptionID="<subscription-id>",timeGrain="Monthly"} 1
# HELP azurerm_budgets_limit Azure ResourceManager consumption budget limit
# TYPE azurerm_budgets_limit gauge
azurerm_budgets_limit{budgetName="Azure_Example_Budget",resourceGroup="",resourceID="/subscriptions/<subscription-id>/providers/microsoft.consumption/budgets/Azure_Example_Budget",scope="/subscriptions/<subscription-id>/",subscriptionID="<subscription-id>"} 50
# HELP azurerm_budgets_usage Azure ResourceManager consumption budget usage percentage
# TYPE azurerm_budgets_usage gauge
azurerm_budgets_usage{budgetName="Azure_Example_Budget",resourceGroup="",resourceID="/subscriptions/<subscription-id>/providers/microsoft.consumption/budgets/Azure_Example_Budget",scope="/subscriptions/<subscription-id>/",subscriptionID="<subscription-id>"} 0.4825012995033831
   
   ```