### PR TITLE
sec: [CVE-2025-68121] Upgrade toolchain to go1.25.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/webdevops/azure-resourcemanager-exporter
 
 go 1.25.0
 
-toolchain go1.25.5
+toolchain go1.25.8
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0


### PR DESCRIPTION
The used Go toolchain version 1.25.5 contains a Critical CVE [CVE-2025-68121](https://avd.aquasec.com/nvd/2025/cve-2025-68121/).

This PR upgrades to the latest available toolchain version in 1.25 (1.25.8) which fixes this vulnerability.